### PR TITLE
Update README.md

### DIFF
--- a/lesson-graphql-client-query/README.md
+++ b/lesson-graphql-client-query/README.md
@@ -49,7 +49,7 @@ _Hint_: Get Luke by his id, which you can get from `allPeople`.
 
 - Query the population and all the residents on the planet Naboo.
 
-2. Use the Github GraphQL API `https://developer.github.com/v4/explorer/` to query
+2. Use the Github GraphQL API `https://docs.github.com/en/free-pro-team@latest/graphql/overview/explorer` to query
 
 - Your repositories (first 10)
 - Extend the query to show the default branch of each repository


### PR DESCRIPTION
When going through the exercise, I noticed that the link to the GitHub GraphQL API explorer is deprecated.